### PR TITLE
Update Lambda function IAM permissions to be less permissive

### DIFF
--- a/account_monitor/cloudformation.yaml
+++ b/account_monitor/cloudformation.yaml
@@ -95,9 +95,15 @@ Resources:
             Action:
               - 'kms:Decrypt'
               - 'logs:CreateLogStream'
-              - 'secretsmanager:GetSecretValue'
-              - 'ssm:GetParameter'
             Resource: '*'
+          - Effect: Allow
+            Action:
+              - 'ssm:GetParameter'
+            Resource: !GetAtt rConfigParameter.arn
+          - Effect: Allow
+            Action:
+              - 'secretsmanager:GetSecretValue'
+            Resource: !GetAtt rSnykAPISecret.arn
       Roles:
         - !Ref rLambdaRole
   rLambdaRole:

--- a/account_monitor/cloudformation.yaml
+++ b/account_monitor/cloudformation.yaml
@@ -84,6 +84,22 @@ Resources:
       Action: 'lambda:InvokeFunction'
       Principal: 'events.amazonaws.com'
       SourceArn: !GetAtt rAccountEventsOrgs.Arn
+  rLambdaPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: AWSAccountMonitorPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'kms:Decrypt'
+              - 'logs:CreateLogStream'
+              - 'secretsmanager:GetSecretValue'
+              - 'ssm:GetParameter'
+            Resource: '*'
+      Roles:
+        - !Ref rLambdaRole
   rLambdaRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -96,8 +112,6 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
-      ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/AdministratorAccess'
       Path: /
   rLambdaFunction:
     Type: 'AWS::Lambda::Function'


### PR DESCRIPTION
### What this does

This PR adjusts the AWS Lambda function to use a less permissive IAM Policy. Previously, it was using AdministratorAccess during development, but now can be locked down to ensure only required permissions are needed.

### Notes for the reviewer

CloudTrail Policy Generator was used to pull the services/actions used in this update.

### More information

None